### PR TITLE
Replace category with tags array on notes

### DIFF
--- a/apps/api/src/routes/notes.ts
+++ b/apps/api/src/routes/notes.ts
@@ -15,16 +15,16 @@ const appendNoteSchema = z.object({
 export function createNotesRouter(db: Database, notesRepo: OrganizedNotesRepository): ExpressRouter {
   const router = Router();
 
-  // GET /api/v1/notes - List notes (optional: filter by category)
+  // GET /api/v1/notes - List notes (optional: filter by tag)
   router.get(
     '/',
     asyncHandler(async (req, res) => {
       const userId = 'test-user-1'; // TODO: Get from auth context
-      const { category } = req.query;
+      const { tag } = req.query;
 
       let notes;
-      if (category && typeof category === 'string') {
-        notes = await notesRepo.findByCategory(userId, category);
+      if (tag && typeof tag === 'string') {
+        notes = await notesRepo.findByTag(userId, tag);
       } else {
         notes = await notesRepo.findByUserId(userId);
       }
@@ -39,9 +39,9 @@ export function createNotesRouter(db: Database, notesRepo: OrganizedNotesReposit
     validateBody(createOrganizedNoteSchema),
     asyncHandler(async (req, res) => {
       const userId = 'test-user-1'; // TODO: Get from auth context
-      const { title, content, category, date } = req.body;
+      const { title, content, tags, date } = req.body;
 
-      const note = await notesRepo.create({ userId, title, content, category, date });
+      const note = await notesRepo.create({ userId, title, content, tags, date });
       res.status(201).json(note);
     })
   );
@@ -82,9 +82,9 @@ export function createNotesRouter(db: Database, notesRepo: OrganizedNotesReposit
     validateBody(updateOrganizedNoteSchema),
     asyncHandler(async (req, res) => {
       const { id } = req.params;
-      const { title, content, category } = req.body;
+      const { title, content, tags } = req.body;
 
-      const note = await notesRepo.update(id, { title, content, category });
+      const note = await notesRepo.update(id, { title, content, tags });
       if (!note) {
         throw new ApiError(404, 'Note not found');
       }

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -56,13 +56,13 @@ export const todosAPI = {
 
 // Organized Notes
 export const notesAPI = {
-  list: (category?: string) =>
-    fetchAPI<any[]>(`/notes${category ? `?category=${category}` : ''}`),
-  create: (data: { title: string; content: string; category?: string }) =>
+  list: (tag?: string) =>
+    fetchAPI<any[]>(`/notes${tag ? `?tag=${tag}` : ''}`),
+  create: (data: { title: string; content: string; tags?: string[] }) =>
     fetchAPI('/notes', { method: 'POST', body: JSON.stringify(data) }),
   append: (data: {title: string, contentToAppend: string}) =>
     fetchAPI('/notes/append', { method: 'POST', body: JSON.stringify(data) }),
-  update: (id: string, data: { title?: string; content?: string; category?: string }) =>
+  update: (id: string, data: { title?: string; content?: string; tags?: string[] }) =>
     fetchAPI(`/notes/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
   delete: (id: string) => fetchAPI(`/notes/${id}`, { method: 'DELETE' }),
 };

--- a/apps/web/src/pages/NewNotePage.tsx
+++ b/apps/web/src/pages/NewNotePage.tsx
@@ -1,14 +1,37 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { notesAPI } from '../api/client';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, X } from 'lucide-react';
 
 export default function NewNotePage() {
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const addTag = (tag: string) => {
+    const trimmedTag = tag.trim().toLowerCase();
+    if (trimmedTag && !tags.includes(trimmedTag) && tags.length < 10) {
+      setTags([...tags, trimmedTag]);
+    }
+    setTagInput('');
+  };
+
+  const removeTag = (tagToRemove: string) => {
+    setTags(tags.filter((t) => t !== tagToRemove));
+  };
+
+  const handleTagInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addTag(tagInput);
+    } else if (e.key === 'Backspace' && !tagInput && tags.length > 0) {
+      removeTag(tags[tags.length - 1]);
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -18,7 +41,11 @@ export default function NewNotePage() {
     setError(null);
 
     try {
-      await notesAPI.create({ title: title.trim(), content: content.trim() });
+      await notesAPI.create({
+        title: title.trim(),
+        content: content.trim(),
+        tags: tags.length > 0 ? tags : undefined,
+      });
       navigate('/notes');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create note');
@@ -72,6 +99,43 @@ export default function NewNotePage() {
             rows={12}
             className="input-accent w-full px-4 py-3 resize-y"
           />
+        </div>
+
+        <div>
+          <label htmlFor="tags" className="block text-sm font-medium text-gray-300 mb-2">
+            Tags <span className="text-gray-500">(press Enter or comma to add)</span>
+          </label>
+          <div className="input-accent w-full px-3 py-2 flex flex-wrap items-center gap-2 min-h-[46px]">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="badge-accent px-3 py-1 text-xs flex items-center gap-1"
+              >
+                {tag}
+                <button
+                  type="button"
+                  onClick={() => removeTag(tag)}
+                  className="hover:text-red-400 transition-colors"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </span>
+            ))}
+            <input
+              id="tags"
+              type="text"
+              value={tagInput}
+              onChange={(e) => setTagInput(e.target.value)}
+              onKeyDown={handleTagInputKeyDown}
+              onBlur={() => tagInput && addTag(tagInput)}
+              placeholder={tags.length === 0 ? 'Add tags...' : ''}
+              className="flex-1 bg-transparent border-none outline-none text-gray-200 placeholder-gray-500 min-w-[100px]"
+              disabled={tags.length >= 10}
+            />
+          </div>
+          {tags.length >= 10 && (
+            <p className="text-yellow-500 text-xs mt-1">Maximum 10 tags allowed</p>
+          )}
         </div>
 
         <div className="flex gap-3">

--- a/apps/web/src/pages/NotesPage.tsx
+++ b/apps/web/src/pages/NotesPage.tsx
@@ -6,12 +6,12 @@ import { FileText, X, Plus } from 'lucide-react';
 export default function NotesPage() {
   const [notes, setNotes] = useState<any[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [selectedCategory, setSelectedCategory] = useState<string>('');
+  const [selectedTag, setSelectedTag] = useState<string>('');
 
-  const loadNotes = async (category?: string) => {
+  const loadNotes = async (tag?: string) => {
     setIsLoading(true);
     try {
-      const data = await notesAPI.list(category);
+      const data = await notesAPI.list(tag);
       setNotes(data);
     } catch (error) {
       console.error('Failed to load notes:', error);
@@ -21,8 +21,8 @@ export default function NotesPage() {
   };
 
   useEffect(() => {
-    loadNotes(selectedCategory || undefined);
-  }, [selectedCategory]);
+    loadNotes(selectedTag || undefined);
+  }, [selectedTag]);
 
   const handleDelete = async (id: string) => {
     if (!confirm('Delete this note?')) return;
@@ -35,7 +35,7 @@ export default function NotesPage() {
     }
   };
 
-  const categories = Array.from(new Set(notes.map((n) => n.category).filter(Boolean)));
+  const allTags = Array.from(new Set(notes.flatMap((n) => n.tags || []))).sort();
 
   if (isLoading) {
     return <div className="text-gray-400 text-center py-12">Loading...</div>;
@@ -50,16 +50,16 @@ export default function NotesPage() {
         </div>
 
         <div className="flex items-center gap-3">
-          {categories.length > 0 && (
+          {allTags.length > 0 && (
             <select
-              value={selectedCategory}
-              onChange={(e) => setSelectedCategory(e.target.value)}
+              value={selectedTag}
+              onChange={(e) => setSelectedTag(e.target.value)}
               className="input-accent px-4 py-2"
             >
-              <option value="">All Categories</option>
-              {categories.map((cat) => (
-                <option key={cat} value={cat}>
-                  {cat}
+              <option value="">All Tags</option>
+              {allTags.map((tag) => (
+                <option key={tag} value={tag}>
+                  {tag}
                 </option>
               ))}
             </select>
@@ -96,13 +96,18 @@ export default function NotesPage() {
             >
               <div className="flex items-start justify-between gap-4">
                 <div className="flex-1">
-                  <div className="flex items-center gap-3 mb-2">
-                    {note.category && (
-                      <span className="badge-accent px-3 py-1 shadow-inner text-xs">
-                        {note.category}
-                      </span>
-                    )}
-                  </div>
+                  {note.tags && note.tags.length > 0 && (
+                    <div className="flex items-center gap-2 mb-2 flex-wrap">
+                      {note.tags.map((tag: string) => (
+                        <span
+                          key={tag}
+                          className="badge-accent px-3 py-1 shadow-inner text-xs"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
 
                   <h3 className="text-lg font-semibold text-gray-100 mb-2">
                     {note.title || 'Untitled'}

--- a/packages/database/migrations/0008_replace_category_with_tags.sql
+++ b/packages/database/migrations/0008_replace_category_with_tags.sql
@@ -1,0 +1,17 @@
+-- Add tags column
+ALTER TABLE "organized_notes" ADD COLUMN "tags" jsonb DEFAULT '[]'::jsonb;
+
+-- Migrate existing categories to tags array
+UPDATE "organized_notes"
+SET "tags" = CASE
+  WHEN "category" IS NOT NULL AND "category" != ''
+  THEN jsonb_build_array("category")
+  ELSE '[]'::jsonb
+END;
+
+-- Drop category column and its index
+DROP INDEX IF EXISTS "organized_notes_category_idx";
+ALTER TABLE "organized_notes" DROP COLUMN "category";
+
+-- Add GIN index for tags queries
+CREATE INDEX "organized_notes_tags_idx" ON "organized_notes" USING GIN ("tags");

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -54,8 +54,15 @@
     {
       "idx": 7,
       "version": "5",
-      "when": 1738613000000,
+      "when": 1770217500000,
       "tag": "0007_add_search_vectors",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "5",
+      "when": 1770303900000,
+      "tag": "0008_replace_category_with_tags",
       "breakpoints": true
     }
   ]

--- a/packages/database/src/repositories/organized-notes-repository.ts
+++ b/packages/database/src/repositories/organized-notes-repository.ts
@@ -27,11 +27,29 @@ export class OrganizedNotesRepository {
       .orderBy(desc(organizedNotes.date));
   }
 
-  async findByCategory(userId: string, category: string): Promise<OrganizedNote[]> {
+  async findByTag(userId: string, tag: string): Promise<OrganizedNote[]> {
     return this.db
       .select()
       .from(organizedNotes)
-      .where(and(eq(organizedNotes.userId, userId), eq(organizedNotes.category, category)))
+      .where(
+        and(
+          eq(organizedNotes.userId, userId),
+          sql`${organizedNotes.tags} @> ${JSON.stringify([tag])}::jsonb`
+        )
+      )
+      .orderBy(desc(organizedNotes.date));
+  }
+
+  async findByTags(userId: string, tags: string[]): Promise<OrganizedNote[]> {
+    return this.db
+      .select()
+      .from(organizedNotes)
+      .where(
+        and(
+          eq(organizedNotes.userId, userId),
+          sql`${organizedNotes.tags} ?| ${tags}::text[]`
+        )
+      )
       .orderBy(desc(organizedNotes.date));
   }
 

--- a/packages/database/src/schema/organized-notes.ts
+++ b/packages/database/src/schema/organized-notes.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, index } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, timestamp, index, jsonb } from 'drizzle-orm/pg-core';
 
 export const organizedNotes = pgTable(
   'organized_notes',
@@ -6,7 +6,7 @@ export const organizedNotes = pgTable(
     id: uuid('id').defaultRandom().primaryKey(),
     title: text('title').notNull(),
     content: text('content').notNull(),
-    category: text('category'),
+    tags: jsonb('tags').$type<string[]>().default([]),
     date: timestamp('date', { withTimezone: true }).notNull().defaultNow(),
     userId: text('user_id').notNull(),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
@@ -15,7 +15,6 @@ export const organizedNotes = pgTable(
   (table) => ({
     userIdIdx: index('organized_notes_user_id_idx').on(table.userId),
     dateIdx: index('organized_notes_date_idx').on(table.date),
-    categoryIdx: index('organized_notes_category_idx').on(table.category),
   })
 );
 

--- a/packages/llm/src/validation.ts
+++ b/packages/llm/src/validation.ts
@@ -5,7 +5,7 @@ export const organizedOutputSchema = z.object({
   notes: z.array(
     z.object({
       content: z.string(),
-      category: z.string().optional(),
+      tags: z.array(z.string()).optional().default([]),
     })
   ),
   todos: z.array(

--- a/packages/types/src/__tests__/validation.test.ts
+++ b/packages/types/src/__tests__/validation.test.ts
@@ -71,17 +71,17 @@ describe('Validation Schemas', () => {
       expect(result.success).toBe(true);
     });
 
-    it('should accept note with category and date', () => {
+    it('should accept note with tags and date', () => {
       const date = new Date();
       const result = createOrganizedNoteSchema.safeParse({
         title: 'Note Title',
-        content: 'Note with category',
-        category: 'work',
+        content: 'Note with tags',
+        tags: ['work', 'important'],
         date,
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.category).toBe('work');
+        expect(result.data.tags).toEqual(['work', 'important']);
         expect(result.data.date).toEqual(date);
       }
     });
@@ -131,11 +131,20 @@ describe('Validation Schemas', () => {
       expect(result.success).toBe(false);
     });
 
-    it('should reject category exceeding max length', () => {
+    it('should reject tags exceeding max count', () => {
       const result = createOrganizedNoteSchema.safeParse({
         title: 'Valid title',
         content: 'Valid content',
-        category: 'a'.repeat(101),
+        tags: Array(11).fill('tag'),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject tag exceeding max length', () => {
+      const result = createOrganizedNoteSchema.safeParse({
+        title: 'Valid title',
+        content: 'Valid content',
+        tags: ['a'.repeat(51)],
       });
       expect(result.success).toBe(false);
     });
@@ -144,7 +153,7 @@ describe('Validation Schemas', () => {
   describe('updateOrganizedNoteSchema', () => {
     it('should accept partial updates', () => {
       const result = updateOrganizedNoteSchema.safeParse({
-        category: 'personal',
+        tags: ['personal', 'finance'],
       });
       expect(result.success).toBe(true);
     });

--- a/packages/types/src/validation.ts
+++ b/packages/types/src/validation.ts
@@ -12,14 +12,14 @@ export type CreateCaptureInput = z.infer<typeof createCaptureSchema>;
 export const createOrganizedNoteSchema = z.object({
   title: z.string().min(1, 'Title is required').max(200, 'Title too long'),
   content: z.string().min(1, 'Content is required').max(50000, 'Content too long'),
-  category: z.string().max(100).optional(),
+  tags: z.array(z.string().max(50)).max(10).optional().default([]),
   date: z.date().optional(),
 });
 
 export const updateOrganizedNoteSchema = z.object({
   title: z.string().min(1).max(200).optional(),
   content: z.string().min(1).max(50000).optional(),
-  category: z.string().max(100).optional(),
+  tags: z.array(z.string().max(50)).max(10).optional(),
 });
 
 export type CreateOrganizedNoteInput = z.infer<typeof createOrganizedNoteSchema>;


### PR DESCRIPTION
Replace the single `category` text field on organized_notes with a `tags`
JSONB array field, enabling multiple tags per note.

Changes:
- Database: Add tags column, migrate existing categories, add GIN index
- Repository: Replace findByCategory with findByTag/findByTags methods
- API: Change query param from ?category to ?tag for filtering
- LLM: Update organizedOutputSchema to use tags array
- Frontend: Add tag input UI and display tags as badges on notes

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

Closes #23 
