### PR TITLE
Fix audio permissions in built app

### DIFF
--- a/apps/web/electron/main.ts
+++ b/apps/web/electron/main.ts
@@ -288,6 +288,15 @@ app.whenReady().then(() => {
     }
   });
 
+  // Approve all Chromium-level permission checks and requests.
+  // The app only loads its own bundled content, so macOS TCC is the real
+  // authorization boundary. Without these handlers Chromium maintains
+  // session-scoped permission state that doesn't persist across launches.
+  session.defaultSession.setPermissionCheckHandler(() => true);
+  session.defaultSession.setPermissionRequestHandler((_webContents, _permission, callback) => {
+    callback(true);
+  });
+
   createMainWindow();
   registerGlobalShortcuts();
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -12,7 +12,7 @@
     <meta name="theme-color" content="#6366f1" />
     <meta name="color-scheme" content="dark light" />
   </head>
-  <body>
+  <body style="background-color: #111827">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/apps/web/src/hooks/useAudioRecorder.ts
+++ b/apps/web/src/hooks/useAudioRecorder.ts
@@ -30,7 +30,14 @@ export function useAudioRecorder() {
     const api = window.electronAPI;
     if (!api) return false;
     const granted = await api.requestMicrophonePermission();
-    await checkPermissions();
+    if (granted) {
+      // Trust the askForMediaAccess result directly instead of re-querying
+      // getMediaAccessStatus, which can return stale values and cause a
+      // permission-prompt loop.
+      setPermissionStatus((prev) => prev && { ...prev, microphone: 'granted' });
+    } else {
+      await checkPermissions();
+    }
     return granted;
   }, [checkPermissions]);
 

--- a/apps/web/src/pages/RecordingPage.tsx
+++ b/apps/web/src/pages/RecordingPage.tsx
@@ -69,10 +69,13 @@ export default function RecordingPage() {
   const isSaving = state === 'saving';
   const isActive = isRecording || isPaused;
 
+  // Only gate on microphone permission — screen/system-audio permission is
+  // unreliable on macOS 15+ (getMediaAccessStatus('screen') can report
+  // 'denied' even when granted).  If system audio capture actually fails,
+  // the error from getDisplayMedia is already caught and shown in the UI.
   const needsPermissions =
     permissionStatus &&
-    ((micEnabled && permissionStatus.microphone !== 'granted') ||
-      (systemAudioEnabled && permissionStatus.screen !== 'granted'));
+    micEnabled && permissionStatus.microphone !== 'granted';
 
   return (
     <div


### PR DESCRIPTION
- Permissions were working in `desktop:dev` but not when fully built, this fixes that.