### PR TITLE
Agent DB setup

### DIFF
--- a/docs/M2_AGENT_ARCH.md
+++ b/docs/M2_AGENT_ARCH.md
@@ -1,0 +1,306 @@
+# Agent Architecture Plan
+
+## Mind Melder — Milestone 2
+
+-----
+
+## Overview
+
+The agentic layer transforms Mind Melder from a request/response tool into a system that observes, reasons, and acts on the user’s behalf. Rather than waiting for the user to trigger organization, the agent runs continuously — watching for captures, detecting patterns, and proposing actions that the user can accept, reject, or redirect.
+
+This document defines the architecture for building that agent on top of the existing Electron + React + Express + PostgreSQL stack.
+
+-----
+
+## Core Principle: Act, Don’t Execute
+
+The agent never writes directly to user-facing data. Every proposed action is queued for user approval first. This keeps the user in control, builds trust incrementally, and — critically — turns every interaction into a feedback signal that improves future agent behavior.
+
+-----
+
+## 1. New Architectural Component: Agent Service
+
+### What It Is
+
+A persistent background worker that runs alongside the Express API. It boots with the application, listens for triggers, and runs reasoning loops independently of user requests.
+
+### Where It Lives
+
+Two viable options depending on preference:
+
+- **Embedded in `apps/api`** — Agent runs as a module within the existing Express process. Simpler to start, shares DB connection and LLM client directly. Recommended for Milestone 2.
+- **Separate `apps/agent` package** — Own Node process in the monorepo. Cleaner separation, independently deployable. Better long-term but adds coordination overhead now.
+
+### Responsibilities
+
+1. **Observe** — watch for triggers (new captures, scheduled times, pattern thresholds)
+2. **Reason** — call the LLM with focused context to decide what actions to take
+3. **Queue** — write proposed actions to `agent_actions` table for user approval
+4. **Learn** — store feedback outcomes to improve future reasoning
+
+-----
+
+## 2. The Action Queue
+
+The action queue is the most critical new primitive in the system. It is the boundary between agent reasoning and real user data.
+
+### `agent_actions` Table Schema
+
+> **Implementation note**: The project uses Drizzle ORM. All discriminated text fields (`trigger_type`, `action_type`, `status`) must be defined as `pgEnum` in the schema file — not plain `TEXT`. All tables include a `user_id` column for multi-tenancy consistency with the rest of the schema.
+
+```sql
+CREATE TABLE agent_actions (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         TEXT NOT NULL,         -- required for multi-tenancy (matches all other tables)
+  trigger_type    TEXT NOT NULL,         -- pgEnum: 'capture' | 'scheduled' | 'threshold'
+  trigger_ref     UUID,                  -- reference to the capture or task that triggered this
+  action_type     TEXT NOT NULL,         -- pgEnum: 'create_task' | 'assign_due_date' | 'flag_followup' | 'detect_overcommitment' | 'suggest_defer'
+  action_payload  JSONB NOT NULL,        -- the proposed action data
+  confidence      REAL NOT NULL,         -- 0.0–1.0, agent's self-assessed confidence
+  reason          TEXT NOT NULL,         -- human-readable explanation shown in approval tray
+  status          TEXT NOT NULL DEFAULT 'pending',  -- pgEnum: 'pending' | 'accepted' | 'rejected' | 'redirected' | 'expired'
+  user_correction JSONB,                 -- populated on 'redirected' — what the user changed
+  created_at      TIMESTAMPTZ DEFAULT now(),
+  updated_at      TIMESTAMPTZ DEFAULT now(),
+  resolved_at     TIMESTAMPTZ
+);
+```
+
+### `agent_feedback` Table Schema
+
+```sql
+CREATE TABLE agent_feedback (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          TEXT NOT NULL,         -- required for multi-tenancy
+  action_id        UUID REFERENCES agent_actions(id),
+  outcome          TEXT NOT NULL,         -- pgEnum: 'accepted' | 'rejected' | 'redirected'
+  original_action  JSONB NOT NULL,
+  corrected_action JSONB,                 -- populated on redirect
+  captured_at      TIMESTAMPTZ DEFAULT now()
+);
+```
+
+The feedback table is what makes the agent smarter over time. Acceptance rates, rejection patterns, and redirect diffs are the raw material for tuning prompts and eventually building user-specific heuristics.
+
+### Action Lifecycle
+
+```
+New Capture / Schedule / Threshold
+        ↓
+  Agent reasons (LLM tool call)
+        ↓
+  agent_actions row created (status: pending)
+        ↓
+  Approval tray surfaces to user
+        ↓
+  ┌─────────────────────────────────┐
+  │ Accept  → execute action        │
+  │           → feedback: accepted  │
+  │                                 │
+  │ Reject  → no-op                 │
+  │           → feedback: rejected  │
+  │                                 │
+  │ Redirect → execute amended      │
+  │            → feedback: redirect │
+  └─────────────────────────────────┘
+```
+
+-----
+
+## 3. Trigger Architecture
+
+The agent wakes up via three trigger types, each with a different latency profile and reasoning depth.
+
+### Trigger 1 — Capture Trigger
+
+**When**: Immediately when a new item lands in the inbox.
+
+**What it does**: Processes the new capture in context of recent activity and decides if any immediate actions are warranted — task extraction, due date detection, follow-up flagging.
+
+**Design constraints**: Latency-sensitive. The user just captured something and may still be at their keyboard. Keep the prompt focused and the tool vocabulary narrow. This is not the time for heavy multi-step reasoning.
+
+**Implementation**: POST to `/api/v1/captures` already exists. After the capture is saved, emit an internal event (`captures:new`) that the agent service subscribes to.
+
+-----
+
+### Trigger 2 — Scheduled Trigger
+
+**When**: On a cron schedule — configurable by user, defaulting to morning (8am) and end-of-day (5pm).
+
+**What it does**: Heavier reasoning pass. Today Sheet generation or refresh, overcommitment detection across the full day’s task load, weekly digest generation (Friday EOD).
+
+**Design constraints**: User is not waiting on a response. Afford a more thorough prompt, more context pulled in, multi-step tool calls. Output may be multiple queued actions from a single run.
+
+**Implementation**: Use `node-cron` or a lightweight scheduler within the agent service. Respect user’s configured working hours from their preferences.
+
+-----
+
+### Trigger 3 — Threshold Trigger
+
+**When**: When a monitored condition crosses a defined threshold.
+
+**Examples**:
+
+- A topic appears in 5+ captures without a corresponding task created
+- A flagged follow-up has been sitting unresolved for 3+ days
+- Estimated time for today’s tasks exceeds available working hours by >30%
+- A capture references a person’s name 3+ times across different sessions
+
+**Why it matters**: These feel the most “magical” to users — the agent noticed something they didn’t explicitly ask about. They emerge from pattern recognition, not from a user action or a clock.
+
+**Implementation**: A background polling loop that runs every N minutes, evaluating threshold conditions against current DB state. Conditions are defined as query + threshold pairs, easy to add new ones over time.
+
+-----
+
+## 4. LLM Interaction Pattern
+
+Rather than one large “figure everything out” prompt, the agent uses a series of small, focused tool-calling interactions. This is a deliberate extension of the chat interface pattern already built in Milestone 1.
+
+### Reasoning Loop
+
+```
+Trigger fires
+     ↓
+Build context package
+  - Recent captures (last N hours or since last run)
+  - Existing open tasks
+  - User preferences (working hours, max tasks/day)
+  - Recent feedback patterns (what has the user accepted/rejected)
+     ↓
+Call LLM with tool definitions
+     ↓
+LLM selects tools and arguments
+     ↓
+Tool calls → agent_actions rows (not direct DB writes)
+     ↓
+Pending actions surfaced to user
+```
+
+### Available Agent Tools (Milestone 2)
+
+|Tool                   |Description                                           |Action Type            |
+|-----------------------|------------------------------------------------------|-----------------------|
+|`create_task`          |Extract and create a task from a capture              |`create_task`          |
+|`assign_due_date`      |Attach a due date inferred from capture language      |`assign_due_date`      |
+|`flag_followup`        |Mark a capture as a follow-up requiring future action |`flag_followup`        |
+|`detect_overcommitment`|Surface a warning when today’s load exceeds capacity  |`detect_overcommitment`|
+|`suggest_defer`        |Recommend moving a task to tomorrow or later this week|`suggest_defer`        |
+
+Start with this narrow vocabulary. Expand only after acceptance rates are healthy.
+
+### System Prompt Strategy
+
+The agent’s system prompt has three layers:
+
+1. **Persona** — “You are a focused productivity agent. Your job is to reduce cognitive overhead, not add to it. Only surface actions you are confident about.”
+2. **Context** — injected at runtime: recent captures, open tasks, user patterns, current time and working hours remaining.
+3. **Constraints** — “Prefer no action over a low-confidence action. When uncertain, do not queue. A confidence score below 0.7 should not result in a queued action.”
+
+-----
+
+## 5. Approval Tray (Frontend)
+
+The approval tray is the user-facing surface for all pending agent actions. It must be non-blocking, low-friction, and dismissible.
+
+### Data Flow
+
+The React frontend subscribes to pending actions via SSE (same pattern as streaming chat responses). When the agent writes a new `pending` row to `agent_actions`, the SSE stream pushes it to the renderer.
+
+New API endpoints required:
+
+```
+GET  /api/v1/agent/actions?status=pending     — fetch pending actions
+POST /api/v1/agent/actions/:id/accept         — accept and execute
+POST /api/v1/agent/actions/:id/reject         — reject, record feedback
+POST /api/v1/agent/actions/:id/redirect       — amend and execute, record correction
+GET  /api/v1/agent/actions/stream             — SSE stream for real-time updates
+```
+
+### Tray UX Principles
+
+- Tray badge shows count of pending actions; zero state is invisible
+- Each action card shows: proposed action, the reason the agent surfaced it, confidence indicator
+- Accept is one tap; reject is one tap; redirect opens a minimal edit view
+- Actions older than 24 hours without resolution are auto-expired (not auto-executed)
+- Never block the user’s primary workflow — the tray is ambient, not modal
+
+### Electron Integration
+
+The Electron main process observes pending action count via IPC and can show a native badge or subtle notification when new actions arrive. This uses the same IPC pattern established for the quick-capture hotkey — no new Electron-level architecture required.
+
+-----
+
+## 6. Confidence Threshold Management
+
+Agent fatigue is the primary risk. If the tray fills with low-quality suggestions, users stop engaging with it and the system loses its value.
+
+### Strategy
+
+- **Ship with a high threshold** — only queue actions with confidence ≥ 0.75 at launch
+- **Track acceptance rate** — if rate drops below 60% over a rolling 7-day window, automatically raise the threshold
+- **Expand vocabulary gradually** — don’t add new action types until existing ones are performing well
+- **Surface confidence to the user** — a subtle indicator on each action card builds trust and sets appropriate expectations
+
+### Feedback Loop
+
+As the `agent_feedback` table accumulates data, use it to:
+
+1. Identify which action types have low acceptance — consider removing or tightening them
+2. Identify redirect patterns — if users consistently correct a particular field, adjust the prompt
+3. Build user-specific prompt context — “this user tends to reject defer suggestions; only surface them for items >7 days old”
+
+-----
+
+## 7. How It Fits the Existing Stack
+
+|Layer             |Change Required                                                                |
+|------------------|-------------------------------------------------------------------------------|
+|**PostgreSQL**    |Add `agent_actions` and `agent_feedback` tables                                |
+|**Express API**   |Add agent action endpoints + SSE stream; emit `captures:new` events internally |
+|**Agent Service** |New module within `apps/api` — trigger listeners, scheduler, LLM reasoning loop|
+|**React Frontend**|Add approval tray component; subscribe to SSE action stream                    |
+|**Electron Main** |Add IPC handler for pending action badge count; optional native notification   |
+|**LLM Client**    |Reuse existing abstracted provider interface; agent uses same client as chat   |
+
+No changes required to the Vite build, preload scripts, or quick-capture window.
+
+-----
+
+## 8. Phased Implementation
+
+### Phase A — Foundation
+
+- `agent_actions` and `agent_feedback` tables
+- Agent service scaffolding with capture trigger
+- `create_task` tool only (narrowest possible scope)
+- Approval tray UI (accept/reject, no redirect yet)
+- SSE stream for real-time tray updates
+
+### Phase B — Scheduled Intelligence
+
+- Scheduled trigger with cron
+- Today Sheet generation as an agent action
+- `assign_due_date` and `flag_followup` tools
+- Redirect flow in approval tray
+- Confidence threshold monitoring
+
+### Phase C — Pattern Recognition
+
+- Threshold trigger with configurable conditions
+- `detect_overcommitment` and `suggest_defer` tools
+- Feedback loop informing prompt context
+- Electron badge and native notification integration
+- User preference controls (threshold sensitivity, action type toggles)
+
+-----
+
+## 9. Open Questions
+
+- **Scheduler persistence** — if the app is closed when a scheduled trigger should fire, does it run on next open, skip, or require the app to stay running? Define behavior before Phase B.
+- **Context window limits** — how many captures and tasks to include in the context package before hitting token limits? Define a windowing strategy early.
+- **Multi-action runs** — when a scheduled trigger produces 8 pending actions at once, how does the tray handle the flood? Consider batching or prioritizing by confidence.
+- **Feedback data ownership** — is feedback used only for prompt tuning locally, or does it inform a shared model? Define the data policy before shipping.
+
+-----
+
+*Mind Melder — Agent Architecture Plan — Milestone 2*

--- a/packages/database/migrations/0018_melted_golden_guardian.sql
+++ b/packages/database/migrations/0018_melted_golden_guardian.sql
@@ -1,0 +1,67 @@
+DO $$ BEGIN
+ CREATE TYPE "agent_action_status" AS ENUM('pending', 'accepted', 'rejected', 'redirected', 'expired');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "agent_action_type" AS ENUM('create_task', 'assign_due_date', 'flag_followup', 'detect_overcommitment', 'suggest_defer');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "agent_outcome" AS ENUM('accepted', 'rejected', 'redirected');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "agent_trigger_type" AS ENUM('capture', 'scheduled', 'threshold');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "agent_actions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"trigger_type" "agent_trigger_type" NOT NULL,
+	"trigger_ref" uuid,
+	"action_type" "agent_action_type" NOT NULL,
+	"action_payload" jsonb NOT NULL,
+	"confidence" real NOT NULL,
+	"reason" text NOT NULL,
+	"status" "agent_action_status" DEFAULT 'pending' NOT NULL,
+	"user_correction" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"resolved_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "agent_feedback" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"action_id" uuid,
+	"outcome" "agent_outcome" NOT NULL,
+	"original_action" jsonb NOT NULL,
+	"corrected_action" jsonb,
+	"captured_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_actions_user_id_idx" ON "agent_actions" ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_actions_status_idx" ON "agent_actions" ("status");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_actions_created_at_idx" ON "agent_actions" ("created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_feedback_user_id_idx" ON "agent_feedback" ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_feedback_action_id_idx" ON "agent_feedback" ("action_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_feedback_captured_at_idx" ON "agent_feedback" ("captured_at");--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "agent_actions" ADD CONSTRAINT "agent_actions_trigger_ref_captures_id_fk" FOREIGN KEY ("trigger_ref") REFERENCES "captures"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "agent_feedback" ADD CONSTRAINT "agent_feedback_action_id_agent_actions_id_fk" FOREIGN KEY ("action_id") REFERENCES "agent_actions"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/database/migrations/meta/0018_snapshot.json
+++ b/packages/database/migrations/meta/0018_snapshot.json
@@ -1,0 +1,1463 @@
+{
+  "id": "b1b6cfd7-9bee-4355-9f56-93cdf37e7194",
+  "prevId": "408c73f1-b12b-46bf-a894-5f0021c033e7",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "captures": {
+      "name": "captures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organized_at": {
+          "name": "organized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "captures_user_id_idx": {
+          "name": "captures_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "captures_organized_idx": {
+          "name": "captures_organized_idx",
+          "columns": [
+            "organized_at"
+          ],
+          "isUnique": false
+        },
+        "captures_timestamp_idx": {
+          "name": "captures_timestamp_idx",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "organized_notes": {
+      "name": "organized_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organized_notes_user_id_idx": {
+          "name": "organized_notes_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organized_notes_date_idx": {
+          "name": "organized_notes_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "today_sheets": {
+      "name": "today_sheets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "captures_processed": {
+          "name": "captures_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "todos_included": {
+          "name": "todos_included",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_estimated_minutes": {
+          "name": "total_estimated_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "today_sheets_user_id_idx": {
+          "name": "today_sheets_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "today_sheets_generated_at_idx": {
+          "name": "today_sheets_generated_at_idx",
+          "columns": [
+            "generated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "todos": {
+      "name": "todos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "todo_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "today_sheet_section": {
+          "name": "today_sheet_section",
+          "type": "today_sheet_section",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "today_sheet_order": {
+          "name": "today_sheet_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "today_sheet_id": {
+          "name": "today_sheet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_estimate": {
+          "name": "time_estimate",
+          "type": "time_estimate",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "priority_score": {
+          "name": "priority_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "capture_id": {
+          "name": "capture_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_vote": {
+          "name": "feedback_vote",
+          "type": "feedback_vote",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "feedback_text": {
+          "name": "feedback_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_timestamp": {
+          "name": "feedback_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "todos_user_id_idx": {
+          "name": "todos_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "todos_status_idx": {
+          "name": "todos_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "todos_due_date_idx": {
+          "name": "todos_due_date_idx",
+          "columns": [
+            "due_date"
+          ],
+          "isUnique": false
+        },
+        "todos_today_sheet_section_idx": {
+          "name": "todos_today_sheet_section_idx",
+          "columns": [
+            "today_sheet_section"
+          ],
+          "isUnique": false
+        },
+        "todos_today_sheet_order_idx": {
+          "name": "todos_today_sheet_order_idx",
+          "columns": [
+            "today_sheet_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "todos_today_sheet_id_today_sheets_id_fk": {
+          "name": "todos_today_sheet_id_today_sheets_id_fk",
+          "tableFrom": "todos",
+          "tableTo": "today_sheets",
+          "columnsFrom": [
+            "today_sheet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "todos_capture_id_captures_id_fk": {
+          "name": "todos_capture_id_captures_id_fk",
+          "tableFrom": "todos",
+          "tableTo": "captures",
+          "columnsFrom": [
+            "capture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_user_id_idx": {
+          "name": "templates_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "templates_is_active_idx": {
+          "name": "templates_is_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "llm_provider": {
+          "name": "llm_provider",
+          "type": "llm_provider",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai'"
+        },
+        "llm_model": {
+          "name": "llm_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_temperature": {
+          "name": "llm_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.7
+        },
+        "ollama_base_url": {
+          "name": "ollama_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http://localhost:11434'"
+        },
+        "today_sheet_schedule_enabled": {
+          "name": "today_sheet_schedule_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "today_sheet_time": {
+          "name": "today_sheet_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'08:00'"
+        },
+        "organization_schedule": {
+          "name": "organization_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0 17 * * *'"
+        },
+        "schedule_enabled": {
+          "name": "schedule_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "whisper_enabled": {
+          "name": "whisper_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "whisper_url": {
+          "name": "whisper_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http://127.0.0.1:3005'"
+        },
+        "content_lock_enabled": {
+          "name": "content_lock_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_tag_descriptions": {
+          "name": "include_tag_descriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "organize_schedule_enabled": {
+          "name": "organize_schedule_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "organize_schedule_frequency": {
+          "name": "organize_schedule_frequency",
+          "type": "schedule_frequency",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "organize_schedule_time": {
+          "name": "organize_schedule_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'17:00'"
+        },
+        "organize_schedule_weekday": {
+          "name": "organize_schedule_weekday",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notifications_morning_reminder_enabled": {
+          "name": "notifications_morning_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notifications_morning_reminder_time": {
+          "name": "notifications_morning_reminder_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'09:00'"
+        },
+        "notifications_afternoon_reminder_enabled": {
+          "name": "notifications_afternoon_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notifications_afternoon_reminder_time": {
+          "name": "notifications_afternoon_reminder_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'15:00'"
+        },
+        "notifications_show_overdue": {
+          "name": "notifications_show_overdue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notifications_quiet_hours_start": {
+          "name": "notifications_quiet_hours_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notifications_quiet_hours_end": {
+          "name": "notifications_quiet_hours_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "settings_user_id_idx": {
+          "name": "settings_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_user_id_unique": {
+          "name": "settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      }
+    },
+    "tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_user_id_idx": {
+          "name": "tags_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_user_name_unique": {
+          "name": "tags_user_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      }
+    },
+    "chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_results": {
+          "name": "tool_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_messages_conversation_id_idx": {
+          "name": "chat_messages_conversation_id_idx",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        },
+        "chat_messages_created_at_idx": {
+          "name": "chat_messages_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_conversation_id_conversations_id_fk": {
+          "name": "chat_messages_conversation_id_conversations_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_user_id_idx": {
+          "name": "conversations_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "conversations_updated_at_idx": {
+          "name": "conversations_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "weekly_reviews": {
+      "name": "weekly_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start_date": {
+          "name": "week_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_end_date": {
+          "name": "week_end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "insights": {
+          "name": "insights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weekly_reviews_user_id_idx": {
+          "name": "weekly_reviews_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "weekly_reviews_week_start_date_idx": {
+          "name": "weekly_reviews_week_start_date_idx",
+          "columns": [
+            "week_start_date"
+          ],
+          "isUnique": false
+        },
+        "weekly_reviews_user_week_idx": {
+          "name": "weekly_reviews_user_week_idx",
+          "columns": [
+            "user_id",
+            "week_start_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "token_usage": {
+      "name": "token_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_usage_user_id_idx": {
+          "name": "token_usage_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "token_usage_created_at_idx": {
+          "name": "token_usage_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "token_usage_user_created_at_idx": {
+          "name": "token_usage_user_created_at_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "agent_actions": {
+      "name": "agent_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "agent_trigger_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_ref": {
+          "name": "trigger_ref",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "agent_action_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_payload": {
+          "name": "action_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_action_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_correction": {
+          "name": "user_correction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_actions_user_id_idx": {
+          "name": "agent_actions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "agent_actions_status_idx": {
+          "name": "agent_actions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "agent_actions_created_at_idx": {
+          "name": "agent_actions_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_actions_trigger_ref_captures_id_fk": {
+          "name": "agent_actions_trigger_ref_captures_id_fk",
+          "tableFrom": "agent_actions",
+          "tableTo": "captures",
+          "columnsFrom": [
+            "trigger_ref"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "agent_feedback": {
+      "name": "agent_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_id": {
+          "name": "action_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "agent_outcome",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_action": {
+          "name": "original_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_action": {
+          "name": "corrected_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_feedback_user_id_idx": {
+          "name": "agent_feedback_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "agent_feedback_action_id_idx": {
+          "name": "agent_feedback_action_id_idx",
+          "columns": [
+            "action_id"
+          ],
+          "isUnique": false
+        },
+        "agent_feedback_captured_at_idx": {
+          "name": "agent_feedback_captured_at_idx",
+          "columns": [
+            "captured_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_feedback_action_id_agent_actions_id_fk": {
+          "name": "agent_feedback_action_id_agent_actions_id_fk",
+          "tableFrom": "agent_feedback",
+          "tableTo": "agent_actions",
+          "columnsFrom": [
+            "action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "feedback_vote": {
+      "name": "feedback_vote",
+      "values": {
+        "thumbs_up": "thumbs_up",
+        "thumbs_down": "thumbs_down",
+        "none": "none"
+      }
+    },
+    "time_estimate": {
+      "name": "time_estimate",
+      "values": {
+        "quick": "quick",
+        "medium": "medium",
+        "long": "long",
+        "none": "none"
+      }
+    },
+    "today_sheet_section": {
+      "name": "today_sheet_section",
+      "values": {
+        "must_do_today": "must_do_today",
+        "likely_today": "likely_today",
+        "opportunistic": "opportunistic",
+        "overflow": "overflow",
+        "none": "none"
+      }
+    },
+    "todo_status": {
+      "name": "todo_status",
+      "values": {
+        "pending": "pending",
+        "completed": "completed"
+      }
+    },
+    "llm_provider": {
+      "name": "llm_provider",
+      "values": {
+        "openai": "openai",
+        "anthropic": "anthropic",
+        "ollama": "ollama"
+      }
+    },
+    "schedule_frequency": {
+      "name": "schedule_frequency",
+      "values": {
+        "daily": "daily",
+        "weekly": "weekly"
+      }
+    },
+    "message_role": {
+      "name": "message_role",
+      "values": {
+        "user": "user",
+        "assistant": "assistant",
+        "system": "system",
+        "tool": "tool"
+      }
+    },
+    "agent_action_status": {
+      "name": "agent_action_status",
+      "values": {
+        "pending": "pending",
+        "accepted": "accepted",
+        "rejected": "rejected",
+        "redirected": "redirected",
+        "expired": "expired"
+      }
+    },
+    "agent_action_type": {
+      "name": "agent_action_type",
+      "values": {
+        "create_task": "create_task",
+        "assign_due_date": "assign_due_date",
+        "flag_followup": "flag_followup",
+        "detect_overcommitment": "detect_overcommitment",
+        "suggest_defer": "suggest_defer"
+      }
+    },
+    "agent_outcome": {
+      "name": "agent_outcome",
+      "values": {
+        "accepted": "accepted",
+        "rejected": "rejected",
+        "redirected": "redirected"
+      }
+    },
+    "agent_trigger_type": {
+      "name": "agent_trigger_type",
+      "values": {
+        "capture": "capture",
+        "scheduled": "scheduled",
+        "threshold": "threshold"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1772030734476,
       "tag": "0017_quiet_skin",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "5",
+      "when": 1772047833109,
+      "tag": "0018_melted_golden_guardian",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/repositories/agent-actions-repository.ts
+++ b/packages/database/src/repositories/agent-actions-repository.ts
@@ -1,0 +1,111 @@
+import { eq, and, lt, sql } from 'drizzle-orm';
+import {
+  agentActions,
+  agentFeedback,
+  type AgentAction,
+  type NewAgentAction,
+  type AgentFeedback,
+  type NewAgentFeedback,
+} from '../schema/agent-actions.js';
+import type { Database } from '../client.js';
+
+export class AgentActionsRepository {
+  constructor(private db: Database) {}
+
+  async create(data: NewAgentAction): Promise<AgentAction> {
+    const [action] = await this.db.insert(agentActions).values(data).returning();
+    return action;
+  }
+
+  async findById(id: string): Promise<AgentAction | undefined> {
+    const [action] = await this.db.select().from(agentActions).where(eq(agentActions.id, id));
+    return action;
+  }
+
+  async findPending(userId: string): Promise<AgentAction[]> {
+    return this.db
+      .select()
+      .from(agentActions)
+      .where(and(eq(agentActions.userId, userId), eq(agentActions.status, 'pending')))
+      .orderBy(sql`${agentActions.createdAt} DESC`);
+  }
+
+  async accept(id: string): Promise<AgentAction | undefined> {
+    const now = new Date();
+    const [action] = await this.db
+      .update(agentActions)
+      .set({ status: 'accepted', resolvedAt: now, updatedAt: now })
+      .where(eq(agentActions.id, id))
+      .returning();
+    return action;
+  }
+
+  async reject(id: string): Promise<AgentAction | undefined> {
+    const now = new Date();
+    const [action] = await this.db
+      .update(agentActions)
+      .set({ status: 'rejected', resolvedAt: now, updatedAt: now })
+      .where(eq(agentActions.id, id))
+      .returning();
+    return action;
+  }
+
+  async redirect(id: string, correction: Record<string, unknown>): Promise<AgentAction | undefined> {
+    const now = new Date();
+    const [action] = await this.db
+      .update(agentActions)
+      .set({ status: 'redirected', userCorrection: correction, resolvedAt: now, updatedAt: now })
+      .where(eq(agentActions.id, id))
+      .returning();
+    return action;
+  }
+
+  async expireStale(userId: string): Promise<number> {
+    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const expired = await this.db
+      .update(agentActions)
+      .set({ status: 'expired', updatedAt: new Date() })
+      .where(
+        and(
+          eq(agentActions.userId, userId),
+          eq(agentActions.status, 'pending'),
+          lt(agentActions.createdAt, cutoff)
+        )
+      )
+      .returning();
+    return expired.length;
+  }
+
+  async createFeedback(data: NewAgentFeedback): Promise<AgentFeedback> {
+    const [feedback] = await this.db.insert(agentFeedback).values(data).returning();
+    return feedback;
+  }
+
+  async findFeedbackByActionId(actionId: string): Promise<AgentFeedback | undefined> {
+    const [feedback] = await this.db
+      .select()
+      .from(agentFeedback)
+      .where(eq(agentFeedback.actionId, actionId));
+    return feedback;
+  }
+
+  // Returns acceptance rate (0.0–1.0) over a rolling window of N days.
+  // Used by threshold monitoring to auto-adjust confidence cutoffs.
+  async getAcceptanceRate(userId: string, days: number): Promise<number> {
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    const rows = await this.db
+      .select({ outcome: agentFeedback.outcome })
+      .from(agentFeedback)
+      .where(
+        and(
+          eq(agentFeedback.userId, userId),
+          sql`${agentFeedback.capturedAt} >= ${since}`
+        )
+      );
+
+    if (rows.length === 0) return 1.0;
+
+    const accepted = rows.filter((r) => r.outcome === 'accepted').length;
+    return accepted / rows.length;
+  }
+}

--- a/packages/database/src/repositories/index.ts
+++ b/packages/database/src/repositories/index.ts
@@ -8,3 +8,4 @@ export * from './tags-repository.js';
 export * from './conversations-repository.js';
 export * from './weekly-reviews-repository.js';
 export * from './token-usage-repository.js';
+export * from './agent-actions-repository.js';

--- a/packages/database/src/schema/agent-actions.ts
+++ b/packages/database/src/schema/agent-actions.ts
@@ -1,0 +1,86 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  jsonb,
+  real,
+  index,
+  pgEnum,
+} from 'drizzle-orm/pg-core';
+import { captures } from './captures.js';
+
+export const agentTriggerTypeEnum = pgEnum('agent_trigger_type', [
+  'capture',
+  'scheduled',
+  'threshold',
+]);
+
+export const agentActionTypeEnum = pgEnum('agent_action_type', [
+  'create_task',
+  'assign_due_date',
+  'flag_followup',
+  'detect_overcommitment',
+  'suggest_defer',
+]);
+
+export const agentActionStatusEnum = pgEnum('agent_action_status', [
+  'pending',
+  'accepted',
+  'rejected',
+  'redirected',
+  'expired',
+]);
+
+export const agentOutcomeEnum = pgEnum('agent_outcome', [
+  'accepted',
+  'rejected',
+  'redirected',
+]);
+
+export const agentActions = pgTable(
+  'agent_actions',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    userId: text('user_id').notNull(),
+    triggerType: agentTriggerTypeEnum('trigger_type').notNull(),
+    triggerRef: uuid('trigger_ref').references(() => captures.id, { onDelete: 'set null' }),
+    actionType: agentActionTypeEnum('action_type').notNull(),
+    actionPayload: jsonb('action_payload').notNull(),
+    confidence: real('confidence').notNull(),
+    reason: text('reason').notNull(),
+    status: agentActionStatusEnum('status').notNull().default('pending'),
+    userCorrection: jsonb('user_correction'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+    resolvedAt: timestamp('resolved_at', { withTimezone: true }),
+  },
+  (table) => ({
+    userIdIdx: index('agent_actions_user_id_idx').on(table.userId),
+    statusIdx: index('agent_actions_status_idx').on(table.status),
+    createdAtIdx: index('agent_actions_created_at_idx').on(table.createdAt),
+  })
+);
+
+export const agentFeedback = pgTable(
+  'agent_feedback',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    userId: text('user_id').notNull(),
+    actionId: uuid('action_id').references(() => agentActions.id, { onDelete: 'cascade' }),
+    outcome: agentOutcomeEnum('outcome').notNull(),
+    originalAction: jsonb('original_action').notNull(),
+    correctedAction: jsonb('corrected_action'),
+    capturedAt: timestamp('captured_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    userIdIdx: index('agent_feedback_user_id_idx').on(table.userId),
+    actionIdIdx: index('agent_feedback_action_id_idx').on(table.actionId),
+    capturedAtIdx: index('agent_feedback_captured_at_idx').on(table.capturedAt),
+  })
+);
+
+export type AgentAction = typeof agentActions.$inferSelect;
+export type NewAgentAction = typeof agentActions.$inferInsert;
+export type AgentFeedback = typeof agentFeedback.$inferSelect;
+export type NewAgentFeedback = typeof agentFeedback.$inferInsert;

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -8,3 +8,4 @@ export * from './tags.js';
 export * from './conversations.js';
 export * from './weekly-reviews.js';
 export * from './token-usage.js';
+export * from './agent-actions.js';


### PR DESCRIPTION
## Summary
Closes #154                                                                                                                                                        
                                                                                                                                                                 
  - Adds `agent_actions` and `agent_feedback` tables to the database as the foundational primitive for the M2 agent layer                                          
  - Defines four `pgEnum` types for all discriminated fields (`agent_trigger_type`, `agent_action_type`, `agent_action_status`, `agent_outcome`)
  - Implements `AgentActionsRepository` with full action lifecycle methods (`accept`, `reject`, `redirect`, `expireStale`) and feedback utilities                  
  (`createFeedback`, `getAcceptanceRate`)                   
  - Updates `docs/M2_AGENT_ARCH.md` to align the schema spec with Drizzle ORM conventions (pgEnum, userId for multi-tenancy)

  ## What's changing

  **New files**
  - `packages/database/src/schema/agent-actions.ts` — Drizzle schema for both tables and all enums
  - `packages/database/src/repositories/agent-actions-repository.ts` — repository with CRUD, lifecycle transitions, stale expiry, and rolling acceptance rate query
  - `packages/database/migrations/0018_melted_golden_guardian.sql` — generated migration, applied

  **Updated files**
  - `packages/database/src/schema/index.ts` — exports agent-actions schema
  - `packages/database/src/repositories/index.ts` — exports agent-actions repository
  - `docs/M2_AGENT_ARCH.md` — schema spec updated to reflect Drizzle conventions (pgEnum, userId, updatedAt)

  ## Test plan

  - [ ] `pnpm db:migrate` runs cleanly against a fresh database
  - [ ] `pnpm build` succeeds in the database package
  - [ ] `agent_actions` and `agent_feedback` tables are visible in Drizzle Studio (`pnpm db:studio`)
  - [ ] All four enum types are present in the database
  - [ ] Foreign key from `agent_actions.trigger_ref → captures.id` (set null on delete) is correct
  - [ ] Foreign key from `agent_feedback.action_id → agent_actions.id` (cascade delete) is correct